### PR TITLE
[FIX] fix newline in feature:url

### DIFF
--- a/src/features/url.ts
+++ b/src/features/url.ts
@@ -19,7 +19,7 @@ export const checkForUrl = (msg: Message): void => {
   ]
 
   if (msg.content.length >= MINIMUM_URL_LENGTH) {
-    const msgArr = msg.content.split(' ')
+    const msgArr = msg.content.trim().replace(/\n/gi, ' ').split(' ')
     msgArr.forEach(el => {
       if (validate.isURL(el, urlOptions)) {
         let url: URL;


### PR DESCRIPTION
Newline was not splitting string into array.

## Old
![image](https://user-images.githubusercontent.com/13950466/109517431-8be47900-7aa9-11eb-80cb-23b03f1f9354.png)

## New
![image](https://user-images.githubusercontent.com/13950466/109517454-94d54a80-7aa9-11eb-9ba9-dab487846b5f.png)